### PR TITLE
Prefix single-digit minutes/hours with 0

### DIFF
--- a/src/templates/stats.html
+++ b/src/templates/stats.html
@@ -17,7 +17,9 @@
     <main>
         <div id="explanation">
             <div class="inner">
-                Last known waiting time: {{ last_ping.duration }} minutes on Day {{ last_ping.day - 26 }}, {{ last_ping.pong.hour }}:{{ last_ping.pong.minute }} ({{ last_ping.year - 1983 }}C3).
+                Last known waiting time: {{ last_ping.duration }} minutes on Day
+                {{ last_ping.day - 26 }}, {{ last_ping.pong.hour }}:{% if
+                last_ping.pong.minute is le 9%}0{% endif %}{{ last_ping.pong.minute }} ({{ last_ping.year - 1983 }}C3).
             </div>
         </div>
         <div id="c3q">

--- a/src/templates/stats.html
+++ b/src/templates/stats.html
@@ -18,7 +18,8 @@
         <div id="explanation">
             <div class="inner">
                 Last known waiting time: {{ last_ping.duration }} minutes on Day
-                {{ last_ping.day - 26 }}, {{ last_ping.pong.hour }}:{% if
+                {{ last_ping.day - 26 }}, {% if last_ping.pong.hour is le
+                9%}0{% endif %}{{ last_ping.pong.hour }}:{% if
                 last_ping.pong.minute is le 9%}0{% endif %}{{ last_ping.pong.minute }} ({{ last_ping.year - 1983 }}C3).
             </div>
         </div>


### PR DESCRIPTION
As of now, single-digit minutes and hours are displayed as is, i.e. 17:7 instead of 17:07.
This is a (rather ugly) patch to fix that.
It is semi-tested, which means that I manually added some lines to the csv-file and started the server, and it looked good :)